### PR TITLE
Accept input directly from the CLI instead of input file

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,17 +142,30 @@ USAGE
 # Commands
 
 <!-- commands -->
-* [`module-butler generate`](#module-butler-generate)
+* [`module-butler generate [MODULE1] [MODULE2] [MODULE3] [MODULE4] [MODULE5] [MODULE6] [MODULE7] [MODULE8] [MODULE9] [MODULE10]`](#module-butler-generate-module1-module2-module3-module4-module5-module6-module7-module8-module9-module10)
 * [`module-butler help [COMMAND]`](#module-butler-help-command)
 * [`module-butler init`](#module-butler-init)
 
-## `module-butler generate`
+## `module-butler generate [MODULE1] [MODULE2] [MODULE3] [MODULE4] [MODULE5] [MODULE6] [MODULE7] [MODULE8] [MODULE9] [MODULE10]`
 
 generates modules using module names (comma and/or line separated) in .module-butler/input and template files in the templates directory.
 
 ```
 USAGE
-  $ module-butler generate
+  $ module-butler generate [MODULE1] [MODULE2] [MODULE3] [MODULE4] [MODULE5] [MODULE6] [MODULE7] [MODULE8] [MODULE9] 
+  [MODULE10]
+
+ARGUMENTS
+  MODULE1   Name of module
+  MODULE2   Name of module
+  MODULE3   Name of module
+  MODULE4   Name of module
+  MODULE5   Name of module
+  MODULE6   Name of module
+  MODULE7   Name of module
+  MODULE8   Name of module
+  MODULE9   Name of module
+  MODULE10  Name of module
 
 OPTIONS
   -F, --force  forcibly overwrite existing files

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "rm -rf tsconfig.tsbuildinfo && rm -rf lib && tsc -b",
     "prepack": "rm -rf tsconfig.tsbuildinfo && rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif-dev readme && git add README.md"
+    "readme": "oclif-dev readme",
+    "version": "yarn run readme && git add README.md"
   },
   "bugs": "https://github.com/richardguerre/module-butler/issues",
   "dependencies": {

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -10,6 +10,59 @@ export default class Generate extends Command {
   static description =
     'generates modules using module names (comma and/or line separated) in .module-butler/input and template files in the templates directory.';
 
+  static args = [
+    {
+      name: 'module1',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module2',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module3',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module4',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module5',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module6',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module7',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module8',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module9',
+      description: 'Name of module',
+      required: false,
+    },
+    {
+      name: 'module10',
+      description: 'Name of module',
+      required: false,
+    },
+  ];
+
   static flags = {
     help: flags.help({ char: 'h', description: 'show help for generate command' }),
     force: flags.boolean({
@@ -19,7 +72,7 @@ export default class Generate extends Command {
   };
 
   async run() {
-    const { flags } = this.parse(Generate);
+    const { flags, args } = this.parse(Generate);
     cli.action.start('Initializing generator');
     const root = process.cwd();
     const moduleButlerDir = path.resolve(root, './.module-butler');
@@ -62,9 +115,16 @@ export default class Generate extends Command {
       });
     }
 
-    // read and parse input
-    const inputRaw = await fs.promises.readFile(inputPath, { encoding: 'utf8' });
-    const modules = inputRaw.split(/,+|\s+/).filter((s) => s !== ''); // the filter removes any new line the user might have added between the module names
+    let modules: Array<string> = [];
+    // if user provides module names through args use that instead of input file
+    const argModules = Object.values(args).filter((s) => s);
+    if (argModules.length > 0) {
+      modules = argModules;
+    } else {
+      // read and parse input
+      const inputRaw = await fs.promises.readFile(inputPath, { encoding: 'utf8' });
+      modules = inputRaw.split(/,+|\s+/).filter((s) => s !== ''); // the filter removes any new line the user might have added between the module names
+    }
 
     cli.action.stop(logSymbols.success);
 


### PR DESCRIPTION
```ts
    // if user provides module names through args use that instead of input file
    const argModules = Object.values(args).filter((s) => s);
    if (argModules.length > 0) {
      modules = argModules;
    } else {
      // read and parse input
      const inputRaw = await fs.promises.readFile(inputPath, { encoding: 'utf8' });
      modules = inputRaw.split(/,+|\s+/).filter((s) => s !== ''); // the filter removes any new line the user might have added between the module names
    }
```